### PR TITLE
增加zzz.ini为游戏个性设置

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -1414,6 +1414,11 @@ std::unique_ptr<INISettingsInterface> System::GetGameSettingsInterface(const Gam
   std::unique_ptr<INISettingsInterface> ret;
   std::string path = GetGameSettingsPath(serial, false);
 
+  // 假如存在zzz.ini就指定此文件为游戏个性设置
+  std::string pathzzz = GetGameSettingsPath("zzz", false);
+  if (FileSystem::FileExists(pathzzz.c_str()))
+	  path=pathzzz;
+  
   if (FileSystem::FileExists(path.c_str()))
   {
     if (!quiet)


### PR DESCRIPTION
增加zzz.ini为游戏个性设置

当\gamesettings目录下存在zzz.ini就指定保存个性设置，否则还是 游戏编号.ini 的形式